### PR TITLE
Use lazy getSubscriptionManager for React 18 reusable state

### DIFF
--- a/src/context.test.tsx
+++ b/src/context.test.tsx
@@ -26,11 +26,11 @@ test('should render a Provider which provide the passed pouchdb database', async
   })
 
   expect(result.current.pouchdb).toBe(myPouch)
-  expect(typeof result.current.subscriptionManager).toBe('object')
-  expect(typeof result.current.subscriptionManager.subscribeToDocs).toBe(
+  expect(typeof result.current.getSubscriptionManager).toBe('function')
+  expect(typeof result.current.getSubscriptionManager().subscribeToDocs).toBe(
     'function'
   )
-  expect(typeof result.current.subscriptionManager.subscribeToView).toBe(
+  expect(typeof result.current.getSubscriptionManager().subscribeToView).toBe(
     'function'
   )
 
@@ -48,7 +48,7 @@ test('should unsubscribe all when the database changes', async () => {
   })
 
   const unsubscribe = jest.fn()
-  result.current.subscriptionManager.unsubscribeAll = unsubscribe
+  result.current.getSubscriptionManager().unsubscribeAll = unsubscribe
 
   db = new PouchDB('test2', { adapter: 'memory' })
 
@@ -74,7 +74,7 @@ test('should unsubscribe all when a database gets destroyed', async () => {
   })
 
   const unsubscribe = jest.fn()
-  result.current.subscriptionManager.unsubscribeAll = unsubscribe
+  result.current.getSubscriptionManager().unsubscribeAll = unsubscribe
 
   await myPouch.destroy()
 
@@ -155,19 +155,21 @@ test('should render a Provider that gives access to multiple databases', async (
 
   expect(result.current.pouchdb).toBe(myPouch)
 
-  const myPouchSubscriptionManager = result.current.subscriptionManager
+  const myPouchSubscriptionManager = result.current.getSubscriptionManager()
 
   rerender('other')
 
   expect(result.current.pouchdb).toBe(other)
-  expect(result.current.subscriptionManager).not.toBe(
+  expect(result.current.getSubscriptionManager()).not.toBe(
     myPouchSubscriptionManager
   )
 
   rerender('myPouch')
 
   expect(result.current.pouchdb).toBe(myPouch)
-  expect(result.current.subscriptionManager).toBe(myPouchSubscriptionManager)
+  expect(result.current.getSubscriptionManager()).toBe(
+    myPouchSubscriptionManager
+  )
 
   await myPouch.destroy()
   await other.destroy()
@@ -189,22 +191,24 @@ test('should combine a parent context into its context', async () => {
   })
 
   expect(result.current.pouchdb).toBe(child)
-  const childSubscriptionManager = result.current.subscriptionManager
+  const childSubscriptionManager = result.current.getSubscriptionManager()
 
   rerender('test')
 
   expect(result.current.pouchdb).toBe(parent)
-  expect(result.current.subscriptionManager).not.toBe(childSubscriptionManager)
+  expect(result.current.getSubscriptionManager()).not.toBe(
+    childSubscriptionManager
+  )
 
   rerender('other')
 
   expect(result.current.pouchdb).toBe(child)
-  expect(result.current.subscriptionManager).toBe(childSubscriptionManager)
+  expect(result.current.getSubscriptionManager()).toBe(childSubscriptionManager)
 
   rerender('_default')
 
   expect(result.current.pouchdb).toBe(child)
-  expect(result.current.subscriptionManager).toBe(childSubscriptionManager)
+  expect(result.current.getSubscriptionManager()).toBe(childSubscriptionManager)
 
   await parent.destroy()
   await child.destroy()
@@ -228,22 +232,24 @@ test('should combine a parent context into its context if the child is multi db'
   })
 
   expect(result.current.pouchdb).toBe(child)
-  const childSubscriptionManager = result.current.subscriptionManager
+  const childSubscriptionManager = result.current.getSubscriptionManager()
 
   rerender('test')
 
   expect(result.current.pouchdb).toBe(parent)
-  expect(result.current.subscriptionManager).not.toBe(childSubscriptionManager)
+  expect(result.current.getSubscriptionManager()).not.toBe(
+    childSubscriptionManager
+  )
 
   rerender('other')
 
   expect(result.current.pouchdb).toBe(child)
-  expect(result.current.subscriptionManager).toBe(childSubscriptionManager)
+  expect(result.current.getSubscriptionManager()).toBe(childSubscriptionManager)
 
   rerender('_default')
 
   expect(result.current.pouchdb).toBe(child)
-  expect(result.current.subscriptionManager).toBe(childSubscriptionManager)
+  expect(result.current.getSubscriptionManager()).toBe(childSubscriptionManager)
 
   await parent.destroy()
   await child.destroy()

--- a/src/useAllDocs.ts
+++ b/src/useAllDocs.ts
@@ -17,7 +17,7 @@ export default function useAllDocs<Content>(
       | PouchDB.Core.AllDocsOptions
     )
 ): ResultType<PouchDB.Core.AllDocsResponse<Content>> {
-  const { pouchdb: pouch, subscriptionManager } = useContext(options?.db)
+  const { pouchdb: pouch, getSubscriptionManager } = useContext(options?.db)
 
   const {
     include_docs,
@@ -112,7 +112,7 @@ export default function useAllDocs<Content>(
       keysToSubscribe = keys
     }
 
-    const unsubscribe = subscriptionManager.subscribeToDocs(
+    const unsubscribe = getSubscriptionManager().subscribeToDocs(
       keysToSubscribe,
       (deleted, id) => {
         if (
@@ -146,7 +146,7 @@ export default function useAllDocs<Content>(
     dispatch,
     replace,
     pouch,
-    subscriptionManager,
+    getSubscriptionManager,
     include_docs,
     conflicts,
     attachments,

--- a/src/useDoc.ts
+++ b/src/useDoc.ts
@@ -21,7 +21,7 @@ export default function useDoc<Content>(
 ): DocResultType<Content> {
   type Document = (PouchDB.Core.Document<Content> & PouchDB.Core.GetMeta) | null
 
-  const { pouchdb: pouch, subscriptionManager } = useContext(options?.db)
+  const { pouchdb: pouch, getSubscriptionManager } = useContext(options?.db)
 
   const { rev, revs, revs_info, conflicts, attachments, binary, latest } =
     options || {}
@@ -115,23 +115,26 @@ export default function useDoc<Content>(
         ? () => {
             return
           }
-        : subscriptionManager.subscribeToDocs([id], (deleted, _id, doc) => {
-            if (!isMounted) return
+        : getSubscriptionManager().subscribeToDocs(
+            [id],
+            (deleted, _id, doc) => {
+              if (!isMounted) return
 
-            // If the document got deleted it should change to an 404 error state
-            // or if there is a conflicting version, then it should show the new winning one.
-            if (deleted || revs || revs_info || conflicts || attachments) {
-              fetchDoc()
-            } else {
-              dispatch({
-                type: 'loading_finished',
-                payload: {
-                  doc: doc as PouchDB.Core.Document<Content> &
-                    PouchDB.Core.GetMeta,
-                },
-              })
+              // If the document got deleted it should change to an 404 error state
+              // or if there is a conflicting version, then it should show the new winning one.
+              if (deleted || revs || revs_info || conflicts || attachments) {
+                fetchDoc()
+              } else {
+                dispatch({
+                  type: 'loading_finished',
+                  payload: {
+                    doc: doc as PouchDB.Core.Document<Content> &
+                      PouchDB.Core.GetMeta,
+                  },
+                })
+              }
             }
-          })
+          )
 
     return () => {
       isMounted = false
@@ -140,7 +143,7 @@ export default function useDoc<Content>(
   }, [
     dispatch,
     pouch,
-    subscriptionManager,
+    getSubscriptionManager,
     id,
     rev,
     revs,

--- a/src/useFind.ts
+++ b/src/useFind.ts
@@ -83,7 +83,7 @@ export interface FindHookOptions extends CommonOptions {
 export default function useFind<Content>(
   options: FindHookOptions
 ): ResultType<PouchDB.Find.FindResponse<Content>> {
-  const { pouchdb: pouch, subscriptionManager } = useContext(options.db)
+  const { pouchdb: pouch, getSubscriptionManager } = useContext(options.db)
 
   if (
     typeof pouch?.createIndex !== 'function' ||
@@ -202,7 +202,7 @@ export default function useFind<Content>(
         query()
 
         unsubscribe = subscribe(
-          subscriptionManager,
+          getSubscriptionManager,
           selector,
           query,
           ddocId,
@@ -218,7 +218,7 @@ export default function useFind<Content>(
           query()
 
           unsubscribe = subscribe(
-            subscriptionManager,
+            getSubscriptionManager,
             selector,
             query,
             null,
@@ -233,7 +233,7 @@ export default function useFind<Content>(
     }
   }, [
     pouch,
-    subscriptionManager,
+    getSubscriptionManager,
     dispatch,
     index,
     selector,
@@ -305,14 +305,14 @@ async function findIndex(
 /**
  * Subscribes to updates in the database and re-query
  * when a document did change that matches the selector.
- * @param subscriptionManager - The current subscription manager.
+ * @param getSubscriptionManager - The current subscription manager getter.
  * @param selector - Selector, to filter out changes.
  * @param query - Function to run a query.
  * @param id - Id of the ddoc where the index is stored.
  * @param idsInResult - Object containing a Set of ids in the last result.
  */
 function subscribe(
-  subscriptionManager: SubscriptionManager,
+  getSubscriptionManager: () => SubscriptionManager,
   selector: PouchDB.Find.Selector,
   query: () => void,
   id: PouchDB.Core.DocumentId | null,
@@ -322,7 +322,7 @@ function subscribe(
     ? '_design/' + id.replace(/^_design\//, '') // normalize, user can add a ddoc name
     : undefined
 
-  return subscriptionManager.subscribeToDocs<Record<string, unknown>>(
+  return getSubscriptionManager().subscribeToDocs<Record<string, unknown>>(
     null,
     (_del, id, doc) => {
       if (idsInResult.ids.has(id)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "ES2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "es2015" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["ES2015", "ES2017.object"],       /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,


### PR DESCRIPTION
## Overview

This pull request is an attempt to fix https://github.com/Terreii/use-pouchdb/issues/77.

React 18 introduces a strict mode behavior on initial mount which unmounts and remounts the component with persisted state. In other words, after the render function runs, useEffect and useEffect cleanup functions run _again_, which causes the subscriptions to be removed.

Relevant docs:
https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state
https://github.com/reactwg/react-18/discussions/18

This causes document and view subscriptions to be prematurely unsubscribed in React 18 when rendered in strict mode.

The recommendation from the React team is to switch to a lazy initialization function for side-effects to be shared with other components. This PR changes Provider to expose a lazy getSubscriptionManager function to be used by other hooks' effects.

This is potentially a breaking change if library consumers are using the `subscriptionManager` prop from `<Provider>`, though I don't see it mentioned in the docs.

## Testing recommendations

This is the React 18 test app I used to reproduce this behavior and verify the fix. Without the change, the `doc` subscription will not update and subsequent `put`s will have conflict errors.

```tsx
import React from 'react'
import { createRoot } from 'react-dom/client'
import PouchDB from 'pouchdb'
import { useDoc, Provider, usePouch } from 'use-pouchdb'

const _db = new PouchDB('entities')

function App() {
  const db = usePouch()
  const { doc } = useDoc('count', {}, { count: 0 })

  function handleClick() {
    db.put({ ...doc, count: doc!.count + 1 })
  }

  if (doc == null) {
    return <div>loading</div>
  }

  return (
    <div>
      <div>count: {doc.count}</div>
      <button onClick={handleClick}>increment</button>
    </div>
  )
}

const root = createRoot(document.getElementById('root')!)
root.render(
  <React.StrictMode>
    <Provider pouchdb={_db}>
      <App />
    </Provider>
  </React.StrictMode>,
)
```